### PR TITLE
Harden token handling and refresh flow

### DIFF
--- a/src/main/java/com/sallejoven/backend/config/security/JwtRefreshTokenFilter.java
+++ b/src/main/java/com/sallejoven/backend/config/security/JwtRefreshTokenFilter.java
@@ -14,6 +14,7 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.server.ResponseStatusException;
 import com.sallejoven.backend.repository.RefreshTokenRepository;
+import com.sallejoven.backend.utils.TokenHashUtils;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import java.io.IOException;
@@ -59,7 +60,8 @@ public class JwtRefreshTokenFilter extends OncePerRequestFilter {
 
             if (!userName.isEmpty() && SecurityContextHolder.getContext().getAuthentication() == null) {
                 //Check if refreshToken isPresent in database and is valid
-                var isRefreshTokenValidInDatabase = refreshTokenRepo.findByToken(jwtRefreshToken.getTokenValue())
+                var isRefreshTokenValidInDatabase = refreshTokenRepo.findByTokenHash(
+                                TokenHashUtils.sha256Base64Url(jwtRefreshToken.getTokenValue()))
                         .map(refreshTokenEntity -> !refreshTokenEntity.isRevoked())
                         .orElse(false);
 

--- a/src/main/java/com/sallejoven/backend/controller/AuthController.java
+++ b/src/main/java/com/sallejoven/backend/controller/AuthController.java
@@ -16,7 +16,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.sallejoven.backend.model.dto.UserRegistrationDto;
@@ -47,7 +46,6 @@ public class AuthController {
     public AuthResponseDto refresh(
             @RequestHeader(value = "Authorization", required = false) String authHeader,
             @CookieValue(value = "refresh_token", required = false) String refreshCookie,
-            @RequestParam(value = "refresh_token", required = false) String refreshParam, // <-- NUEVO
             HttpServletResponse response
     ) throws SalleException {
 
@@ -59,12 +57,6 @@ public class AuthController {
         // 2) Fallback cookie
         if (refreshCookie != null && !refreshCookie.isBlank()) {
             String h = "Bearer " + refreshCookie;
-            return (AuthResponseDto) authService.getAccessTokenUsingRefreshToken(h, response);
-        }
-
-        // 3) Fallback body (x-www-form-urlencoded)
-        if (refreshParam != null && !refreshParam.isBlank()) {
-            String h = "Bearer " + refreshParam;
             return (AuthResponseDto) authService.getAccessTokenUsingRefreshToken(h, response);
         }
 

--- a/src/main/java/com/sallejoven/backend/model/entity/PasswordResetToken.java
+++ b/src/main/java/com/sallejoven/backend/model/entity/PasswordResetToken.java
@@ -31,7 +31,7 @@ public class PasswordResetToken {
     private Long id;
 
     @Column(nullable = false, unique = true, length = 200)
-    private String token; // base64url
+    private String tokenHash; // base64url sha-256
 
     @Column(nullable = false)
     private String email;

--- a/src/main/java/com/sallejoven/backend/model/entity/RefreshToken.java
+++ b/src/main/java/com/sallejoven/backend/model/entity/RefreshToken.java
@@ -31,8 +31,8 @@ public class RefreshToken {
     )
     private Long id;
 
-    @Column(name = "token", nullable = false, length = 10000)
-    private String token;
+    @Column(name = "token_hash", nullable = false, length = 128)
+    private String tokenHash;
 
     @Column(name = "revoked")
     private boolean revoked;

--- a/src/main/java/com/sallejoven/backend/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/sallejoven/backend/repository/PasswordResetTokenRepository.java
@@ -7,6 +7,6 @@ import java.time.Instant;
 import java.util.Optional;
 
 public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
-    Optional<PasswordResetToken> findByToken(String token);
+    Optional<PasswordResetToken> findByTokenHash(String tokenHash);
     void deleteAllByExpiresAtBefore(Instant cutoff); // útil para limpieza programada
 }

--- a/src/main/java/com/sallejoven/backend/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sallejoven/backend/repository/RefreshTokenRepository.java
@@ -8,5 +8,5 @@ import com.sallejoven.backend.model.entity.RefreshToken;
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
-    Optional<RefreshToken> findByToken(String refreshToken);
+    Optional<RefreshToken> findByTokenHash(String refreshTokenHash);
 }

--- a/src/main/java/com/sallejoven/backend/service/AuthService.java
+++ b/src/main/java/com/sallejoven/backend/service/AuthService.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 
 import com.sallejoven.backend.config.security.JwtProperties;
 import com.sallejoven.backend.model.enums.ErrorCodes;
+import com.sallejoven.backend.utils.TokenHashUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -114,7 +115,7 @@ public class AuthService {
         }
 
         // 2) Verificar en BD que no está revocado
-        var refreshTokenEntity = refreshTokenRepo.findByToken(refreshToken)
+        var refreshTokenEntity = refreshTokenRepo.findByTokenHash(TokenHashUtils.sha256Base64Url(refreshToken))
                 .filter(tokens -> !tokens.isRevoked())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Refresh token revoked"));
 
@@ -192,7 +193,7 @@ public class AuthService {
     private void saveUserRefreshToken(UserSalle userInfoEntity, String refreshToken) {
         var refreshTokenEntity = RefreshToken.builder()
                 .user(userInfoEntity)
-                .token(refreshToken)
+                .tokenHash(TokenHashUtils.sha256Base64Url(refreshToken))
                 .revoked(false)
                 .build();
         refreshTokenEntity.setId(null);
@@ -202,7 +203,7 @@ public class AuthService {
     public UserSalle registerUser(UserRegistrationDto userRegistrationDto,HttpServletResponse httpServletResponse){
 
         try{
-            log.info("[AuthService:registerUser]User Registration Started with :::{}",userRegistrationDto);
+            log.info("[AuthService:registerUser]User Registration Started for email:{}", userRegistrationDto.userEmail());
 
             Optional<UserSalle> user = userInfoRepo.findByEmail(userRegistrationDto.userEmail());
             if(user.isPresent()){

--- a/src/main/java/com/sallejoven/backend/service/LogoutHandlerService.java
+++ b/src/main/java/com/sallejoven/backend/service/LogoutHandlerService.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.Authentication;
 
 import com.sallejoven.backend.model.enums.TokenType;
 import com.sallejoven.backend.repository.RefreshTokenRepository;
+import com.sallejoven.backend.utils.TokenHashUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +31,7 @@ public class LogoutHandlerService implements LogoutHandler {
 
         final String refreshToken = authHeader.substring(7);
         
-        var storedRefreshToken = refreshTokenRepo.findByToken(refreshToken)
+        var storedRefreshToken = refreshTokenRepo.findByTokenHash(TokenHashUtils.sha256Base64Url(refreshToken))
                 .map(token->{
                     token.setRevoked(true);
                     refreshTokenRepo.save(token);

--- a/src/main/java/com/sallejoven/backend/service/PasswordResetService.java
+++ b/src/main/java/com/sallejoven/backend/service/PasswordResetService.java
@@ -12,6 +12,7 @@ import org.springframework.mail.javamail.MimeMessageHelper;      // <---
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
+import com.sallejoven.backend.utils.TokenHashUtils;
 
 import jakarta.mail.internet.MimeMessage;                     // <---
 import java.net.URLEncoder;
@@ -54,7 +55,7 @@ public class PasswordResetService {
         final Instant exp = now.plus(Duration.ofMinutes(10));
 
         PasswordResetToken prt = new PasswordResetToken();
-        prt.setToken(token);
+        prt.setTokenHash(TokenHashUtils.sha256Base64Url(token));
         prt.setEmail(email);
         prt.setCreatedAt(now);
         prt.setExpiresAt(exp);
@@ -69,7 +70,7 @@ public class PasswordResetService {
 
     @Transactional
     public void confirmReset(String token, String newPassword) {
-        PasswordResetToken prt = tokenRepo.findByToken(token)
+        PasswordResetToken prt = tokenRepo.findByTokenHash(TokenHashUtils.sha256Base64Url(token))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "token_invalid"));
 
         if (prt.isUsed() || prt.getExpiresAt().isBefore(Instant.now())) {

--- a/src/main/java/com/sallejoven/backend/utils/TokenHashUtils.java
+++ b/src/main/java/com/sallejoven/backend/utils/TokenHashUtils.java
@@ -1,0 +1,25 @@
+package com.sallejoven.backend.utils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public final class TokenHashUtils {
+
+    private TokenHashUtils() {
+    }
+
+    public static String sha256Base64Url(String value) {
+        if (value == null) {
+            return "";
+        }
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(hashed);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Avoid persisting raw refresh and password-reset tokens to reduce risk of token leakage and replay. 
- Ensure token lookups are performed against a safe, non-reversible representation. 
- Remove an insecure/ambiguous fallback path for refresh token delivery and reduce sensitive logging.

### Description
- Add `TokenHashUtils` with `sha256Base64Url` to produce URL-safe SHA-256 hashes for tokens and use it across the codebase.
- Switch `RefreshToken` and `PasswordResetToken` entities to store `tokenHash` instead of the raw `token` and update their repositories to expose `findByTokenHash`.
- Update `AuthService`, `JwtRefreshTokenFilter`, and `LogoutHandlerService` to hash incoming refresh tokens before DB lookups and to persist the hash when creating refresh records.
- Update `PasswordResetService` to persist reset tokens as hashes and to validate incoming tokens by hashing them; remove the `refresh_token` query-parameter fallback in `AuthController` and reduce registration logging detail.

### Testing
- No automated tests were run as part of this change (no CI/test execution requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69811da42774832bab8a084f85d19867)